### PR TITLE
Correct (probable) typo in docs

### DIFF
--- a/doc/manual.org
+++ b/doc/manual.org
@@ -565,7 +565,7 @@ predicating which will cause the simulation to end when it becomes true.
 For instance
 #+begin_src xml
   <trajectory spec="StochasticTrajectory"
-              endsWhen="X=100">
+              endsWhen="X==100">
   ...
   </trajectory>
 #+end_src


### PR DESCRIPTION
The examples use `==` for equality condition.