### PR TITLE
Possible fix for interval-based coalescent waiting-time sampling

### DIFF
--- a/test/remaster/reactionboxes/ContinuousCoalescentReactionBoxTest.java
+++ b/test/remaster/reactionboxes/ContinuousCoalescentReactionBoxTest.java
@@ -1,0 +1,92 @@
+package remaster.reactionboxes;
+
+import beast.base.util.Randomizer;
+import org.junit.Assert;
+import org.junit.Test;
+import remaster.Lineage;
+import remaster.ReactElement;
+import remaster.Reaction;
+
+import java.util.*;
+
+public class ContinuousCoalescentReactionBoxTest {
+
+    private static final double CURRENT_TIME = 0.0;
+    private static final double INTERVAL_END = 1.0;
+    private static final double PER_PAIR_RATE = 0.05;
+    private static final int DRAW_COUNT = 20000;
+
+    private ContinuousCoalescentReactionBox createTwoLineageBox() {
+        Reaction reaction = new Reaction();
+        reaction.initByName("value", "2pop -> pop",
+                "rate", PER_PAIR_RATE + " " + PER_PAIR_RATE,
+                "changeTimes", Double.toString(INTERVAL_END));
+
+        Set<ReactElement> popElements = new HashSet<>();
+        popElements.add(new ReactElement("pop", 0, true));
+
+        return new ContinuousCoalescentReactionBox(reaction, popElements);
+    }
+
+    private Map<ReactElement, List<Lineage>> createTwoLineageState() {
+        ReactElement popEl = new ReactElement("pop", 0, true);
+        List<Lineage> lineageList = new ArrayList<>();
+        lineageList.add(new Lineage(popEl, CURRENT_TIME));
+        lineageList.add(new Lineage(popEl, CURRENT_TIME));
+
+        Map<ReactElement, List<Lineage>> lineages = new HashMap<>();
+        lineages.put(popEl, lineageList);
+
+        return lineages;
+    }
+
+    private static double legacySampler(double u) {
+        double t = CURRENT_TIME;
+        double propensity = PER_PAIR_RATE;
+        double dt = -Math.log(u) / propensity;
+        double intervalEnd = INTERVAL_END;
+
+        while (t + dt > intervalEnd) {
+            u -= 1.0 - Math.exp(-(intervalEnd - t) * propensity);
+            t = intervalEnd;
+            intervalEnd = Double.POSITIVE_INFINITY;
+            dt = -Math.log(u) / propensity;
+        }
+
+        return t + dt;
+    }
+
+    @Test
+    public void fixedSamplerProducesFiniteTimesAndExpectedMean() {
+        Randomizer.setSeed(53);
+
+        ContinuousCoalescentReactionBox box = createTwoLineageBox();
+        Map<ReactElement, List<Lineage>> lineages = createTwoLineageState();
+
+        double sum = 0.0;
+        for (int i = 0; i < DRAW_COUNT; i++) {
+            double t = box.getNextReactionTime(CURRENT_TIME, lineages);
+            Assert.assertTrue("reaction time must be finite", Double.isFinite(t));
+            Assert.assertTrue("reaction time must be >= current time", t >= CURRENT_TIME);
+            sum += t - CURRENT_TIME;
+        }
+
+        double sampleMean = sum / DRAW_COUNT;
+        double expectedMean = 1.0 / PER_PAIR_RATE;
+        Assert.assertEquals(expectedMean, sampleMean, 0.7);
+    }
+
+    @Test
+    public void legacyFormulaCanProduceNaNUnderIntervalCrossing() {
+        Randomizer.setSeed(53);
+
+        int nanCount = 0;
+        for (int i = 0; i < DRAW_COUNT; i++) {
+            double t = legacySampler(Randomizer.nextDouble());
+            if (Double.isNaN(t))
+                nanCount += 1;
+        }
+
+        Assert.assertTrue("legacy interval update should produce NaN draws", nanCount > 0);
+    }
+}


### PR DESCRIPTION
Hi Dr. Vaughan, thank you for ReMASTER.

I noticed what seems to be a bug while running simulations with piecewise-changing migration rates (interval-based rates). I may be misunderstanding the intended behavior, so I wanted to share this as a tentative fix and ask for feedback.

## Motivation / observed issue
During interval-based simulations, waiting-time draws across interval boundaries looked inconsistent, and in regression checks this could lead to non-finite sampled times.

## Proposed fix
In `ContinuousCoalescentReactionBox#getNextReactionTime`, this PR uses cumulative-hazard inversion for piecewise-constant hazards:

- draw `w = -log(u)` once
- walk intervals with `h = lambda * dt`
- if `w <= h`, return in-interval time; otherwise `w -= h` and continue

This seems to resolve the issue in my tests, but I’m not fully sure this is the best/only correct approach, so I’d really appreciate review.

## Regression test added
- `test/remaster/reactionboxes/ContinuousCoalescentReactionBoxTest.java`

This test checks:
- finite times and expected mean behavior for the fixed sampler
- legacy interval update can produce NaN in the same setup

## Validation
`ant test` passes locally.

Below is a supplementary text from AI to help me understanding the issue

---

> 
> ## How Waiting Times *Should* Be Sampled
> ### Constant-rate case (easy)
> If the propensity is constant, `lambda`, the waiting time `T` to the next event is exponential:
> 
> ```
> T = -log(U) / lambda         where U ~ Uniform(0,1)
> ```
> 
> This is standard.
> 
> ### Time-varying case (the one we care about)
> If the rate changes with time (non-homogeneous process), you still start with one uniform draw, but you must solve:
> 
> ```
> ∫ lambda(t) dt  =  -log(U)
> ```
> 
> ReMASTER commonly represents `lambda(t)` as **piecewise constant** over time intervals.
> 
> In that case, the integral is a sum across intervals:
> 
> 1. Draw `w = -log(U)` once.
> 2. Walk forward in time interval-by-interval, subtracting each interval’s “hazard mass”:
>    - `h = lambda_interval × (interval_length)`
>    - if `w <= h`, the event occurs inside this interval at offset `w / lambda_interval`
>    - otherwise set `w = w - h` and move to the next interval
> 
> This algorithm is exactly what our fix implements.
> 
> ## What Was Wrong in ReMASTER (Conceptually)
> The buggy code lives in:
> 
> - `remaster.reactionboxes.ContinuousCoalescentReactionBox.getNextReactionTime()`
> - specifically the branch used when a `Reaction` has interval rates (`popFunc == null`)
> 
> When the initially sampled waiting time would cross an interval boundary, the old code tried to “update” the original uniform random number `U` like this (simplified):
> 
> ```
> U = U - (1 - exp(-lambda_old * Δt))
> T = -log(U) / lambda_new
> ```
> 
> This update is **not** the correct inverse-CDF logic for a piecewise-constant hazard.
> 
> To be concrete: if you insist on carrying a single `U` across interval boundaries, you must **condition on survival** through the interval.
> For a constant rate `lambda_old` over an interval of length `Δt`, survival is `S = exp(-lambda_old * Δt)`.
> If your original draw was `U` (used as a survival threshold in `T = -log(U)/lambda`), then after surviving `Δt` the correctly-updated uniform is:
> 
> ```
> U_new = U / S = U / exp(-lambda_old * Δt)
> ```
> 
> ReMASTER’s old code subtracted CDF mass instead of performing this conditional renormalization, so the remaining-time distribution was wrong.
> 
> Two practical consequences:
> 
> 1. **Bias**: even when `U` stays positive, the resulting waiting time distribution is wrong.
> 2. **NaNs**: the subtraction can push `U <= 0`, so `log(U)` becomes `NaN`.
> 
> And why do NaNs matter? In ReMASTER’s event loop, the simulator picks the *earliest* next event time across all reactions. In Java, comparisons like `if (NaN < bestTime)` are always false, so a `NaN` reaction time is effectively treated as “never happens”, suppressing that reaction.